### PR TITLE
Update README.md to point to Akka.NET Virtual Meetup video demo of the DSL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 A handy DSL for creating [Akka.net](http://getakka.net/) actor protocols and reducing boilerplate.
 
-Heavily influenced by the Lokad DSL
+Heavily influenced by the Lokad DSL.
+
+For a brief video description and demo of usage, watch the [Akka.NET Virtual Meetup 1/26/2016](https://www.youtube.com/watch?v=G3ZafPNI-hk), 
+specifically the time between 6:05 and 30:30 where Chris Martin provides an explanation and demo.
+
 ##Installation
 - A) Compile
 - B) Install `EventDayDsl.vsix` from `EventDayDsl\bin\Debug` (Built in Step A)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A handy DSL for creating [Akka.net](http://getakka.net/) actor protocols and red
 
 Heavily influenced by the Lokad DSL.
 
-For a brief video description and demo of usage, watch the [Akka.NET Virtual Meetup 1/26/2016](https://www.youtube.com/watch?v=G3ZafPNI-hk), 
-specifically the time between 6:05 and 30:30 where Chris Martin provides an explanation and demo.
+For a brief video description and demo of usage by Chris Martin, watch the [Akka.NET Virtual Meetup 1/26/2016](https://www.youtube.com/watch?v=G3ZafPNI-hk), 
+specifically the time between 6:05 and 30:30.
 
 ##Installation
 - A) Compile


### PR DESCRIPTION
The video provides a good overview and demo of the usage.  Thought it should be included in the repo, since the video isn't really "bing-able" with respect to this dsl.

(Sorry for the dual commits, didn't squash.)
